### PR TITLE
Add token account type and update gui

### DIFF
--- a/src/main/java/com/example/addon/gui/screens/accounts/AddTokenAccountScreen.java
+++ b/src/main/java/com/example/addon/gui/screens/accounts/AddTokenAccountScreen.java
@@ -1,0 +1,41 @@
+package com.example.addon.gui.screens.accounts;
+
+import meteordevelopment.meteorclient.gui.GuiTheme;
+import meteordevelopment.meteorclient.gui.screens.accounts.AccountsScreen;
+import meteordevelopment.meteorclient.gui.screens.accounts.AddAccountScreen;
+import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
+import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
+import meteordevelopment.meteorclient.systems.accounts.Account;
+import meteordevelopment.meteorclient.systems.accounts.types.EasyMCAccount;
+
+public class AddTokenAccountScreen extends AddAccountScreen {
+    public AddTokenAccountScreen(GuiTheme theme, AccountsScreen parent) {
+        super(theme, "Add a Token Account", parent);
+    }
+
+    @Override
+    public void initWidgets() {
+        WTable table = add(theme.table()).widget();
+
+        table.add(theme.label("Token:"));
+        WTextBox token = table.add(theme.textBox("")).minWidth(400).expandX().widget();
+        token.setFocused(true);
+
+        table.row();
+
+        add = table.add(theme.button("Add")).expandX().widget();
+        Runnable addAction = () -> onAddPressed(token);
+        add.action = addAction;
+        enterAction = addAction;
+    }
+
+    private void onAddPressed(WTextBox token) {
+        String value = token.get();
+        if (value.isEmpty()) return;
+
+        // Use EasyMCAccount as the token-based account implementation available in Meteor
+        Account<?> account = new EasyMCAccount(value);
+        AccountsScreen.addAccount(this, parent, account);
+    }
+}

--- a/src/main/java/com/example/addon/mixin/AccountScreenMixin.java
+++ b/src/main/java/com/example/addon/mixin/AccountScreenMixin.java
@@ -1,7 +1,34 @@
 package com.example.addon.mixin;
 
-// Mixin removed for now to focus on command functionality
-// The Cubic button will be added through the command system instead
-public class AccountScreenMixin {
-    // This class is kept for future implementation
+import com.example.addon.gui.screens.accounts.AddTokenAccountScreen;
+import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.gui.GuiTheme;
+import meteordevelopment.meteorclient.gui.GuiThemes;
+import meteordevelopment.meteorclient.gui.screens.accounts.AccountsScreen;
+import meteordevelopment.meteorclient.gui.widgets.WWidget;
+import meteordevelopment.meteorclient.gui.widgets.containers.WHorizontalList;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
+import meteordevelopment.meteorclient.gui.utils.Cell;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = AccountsScreen.class, remap = false)
+public abstract class AccountScreenMixin {
+    @Shadow
+    public abstract <W extends WWidget> Cell<W> add(W widget);
+
+    @Inject(method = "initWidgets", at = @At("TAIL"))
+    private void cubic$addTokenButton(CallbackInfo ci) {
+        GuiTheme theme = GuiThemes.get();
+
+        WHorizontalList row = theme.horizontalList();
+        this.add(row).expandX();
+
+        WButton tokenButton = theme.button("Token Account");
+        tokenButton.action = () -> MeteorClient.mc.setScreen(new AddTokenAccountScreen(theme, (AccountsScreen) (Object) this));
+        row.add(tokenButton);
+    }
 } 

--- a/src/main/resources/cubic-addon.mixins.json
+++ b/src/main/resources/cubic-addon.mixins.json
@@ -2,7 +2,9 @@
   "required": true,
   "package": "com.example.addon.mixin",
   "compatibilityLevel": "JAVA_17",
-  "client": [],
+  "client": [
+    "AccountScreenMixin"
+  ],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
Add a "Token Account" button and dedicated GUI to integrate a new token-based account type.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c01c2e6-adbc-4d40-a353-0ac0ba406ebc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c01c2e6-adbc-4d40-a353-0ac0ba406ebc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

